### PR TITLE
Avoid potential race condition by making Storage thread safe

### DIFF
--- a/Sources/NetShears/Storage.swift
+++ b/Sources/NetShears/Storage.swift
@@ -20,7 +20,7 @@ final class Storage: NSObject {
 
     func saveRequest(request: NetShearsRequestModel) {
         accessQueue.async(flags: .barrier) { [weak self] in
-            guard let self else {
+            guard let self = self else {
                 return
             }
             if let index = self.requests.firstIndex(where: { (req) -> Bool in

--- a/Sources/NetShears/Storage.swift
+++ b/Sources/NetShears/Storage.swift
@@ -43,7 +43,7 @@ final class Storage: NSObject {
     private func getFilteredRequests() -> [NetShearsRequestModel] {
         var localRequests = [NetShearsRequestModel]()
         accessQueue.sync {
-            localRequests =  requests
+            localRequests = requests
         }
         return Self.filterRequestsIfNeeded(localRequests)
     }

--- a/Sources/NetShears/Storage.swift
+++ b/Sources/NetShears/Storage.swift
@@ -41,17 +41,18 @@ final class Storage: NSObject {
     }
 
     private func getFilteredRequests() -> [NetShearsRequestModel] {
-        var filteredRequestes = [NetShearsRequestModel]()
+        var localRequests = [NetShearsRequestModel]()
         accessQueue.sync {
-            guard case Ignore.enabled(let ignoreHandler) = NetShears.shared.ignore else {
-                filteredRequestes =  requests
-                return
-            }
-            filteredRequestes = requests.filter { ignoreHandler($0) == false }
-
+            localRequests =  requests
         }
-        return filteredRequestes
+        return Self.filterRequestsIfNeeded(localRequests)
+    }
 
+    private static func filterRequestsIfNeeded(_ requests: [NetShearsRequestModel]) -> [NetShearsRequestModel] {
+        guard case Ignore.enabled(let ignoreHandler) = NetShears.shared.ignore else {
+            return requests
+        }
+        return  requests.filter { ignoreHandler($0) == false }
     }
 
 }


### PR DESCRIPTION
access to the requests array on [Storage.swift](https://github.com/divar-ir/NetShears/compare/master...mjbashtani:NetShears:fixPotentialRaceConditionInRequestsList#diff-49beb40c90a45e9a50a419511e63b563783485df06e378f5054fdd8004005cd0) can cause race condition issues, so this can be avoided by wrapping read and write blocks on another queue 