### PR TITLE
Add progress delegate

### DIFF
--- a/Sources/NetShears/NetShears.swift
+++ b/Sources/NetShears/NetShears.swift
@@ -17,10 +17,16 @@ public extension BodyExporterDelegate {
     func netShears(exportRequestBodyFor request: NetShearsRequestModel) -> BodyExportType { .default }
 }
 
+public protocol TaskProgressDelegate: AnyObject {
+    func task(_ url: URL, didRecieveProgress progress: Progress)
+}
+
 public final class NetShears: NSObject {
     
     public static let shared = NetShears()
     public weak var bodyExportDelegate: BodyExporterDelegate?
+    public weak var taskProgressDelegate: TaskProgressDelegate?
+    
     internal var loggerEnable = false
     internal var interceptorEnable = false
     internal var listenerEnable = false

--- a/Sources/NetShears/URLProtocol/NetworkInterceptorUrlProtocol.swift
+++ b/Sources/NetShears/URLProtocol/NetworkInterceptorUrlProtocol.swift
@@ -121,5 +121,11 @@ extension NetworkInterceptorUrlProtocol: URLSessionDataDelegate {
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
         client?.urlProtocolDidFinishLoading(self)
     }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        if let url = task.currentRequest?.url {
+            NetShears.shared.taskProgressDelegate?.task(url, didRecieveProgress: task.progress)
+        }
+    }
 }
 

--- a/Sources/NetShears/URLProtocol/NetworkLoggerUrlProtocol.swift
+++ b/Sources/NetShears/URLProtocol/NetworkLoggerUrlProtocol.swift
@@ -137,6 +137,12 @@ extension NetworkLoggerUrlProtocol: URLSessionDataDelegate {
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
         client?.urlProtocolDidFinishLoading(self)
     }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        if let url = task.currentRequest?.url {
+            NetShears.shared.taskProgressDelegate?.task(url, didRecieveProgress: task.progress)
+        }
+    }
 }
 
 

--- a/Sources/NetShears/URLProtocol/NetwrokListenerUrlProtocol.swift
+++ b/Sources/NetShears/URLProtocol/NetwrokListenerUrlProtocol.swift
@@ -137,6 +137,12 @@ extension NetwrokListenerUrlProtocol: URLSessionDataDelegate {
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
         client?.urlProtocolDidFinishLoading(self)
     }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        if let url = task.currentRequest?.url {
+            NetShears.shared.taskProgressDelegate?.task(url, didRecieveProgress: task.progress)
+        }
+    }
 }
 
 


### PR DESCRIPTION
Since `URLProtocol` interfere with upload progress tracking, this PR adds a delegate method which propagates upload progress changes so that it would be possible to get the latest progress data.